### PR TITLE
Fix issues when downloading FSO builds from GitHub

### DIFF
--- a/src/com/fsoinstaller/common/BaseURL.java
+++ b/src/com/fsoinstaller/common/BaseURL.java
@@ -85,7 +85,10 @@ public class BaseURL
 			throw new IllegalArgumentException("The URI cannot be null!");
 		
 		// check protocol
-		if (theURL.getScheme() == null || !theURL.getScheme().toLowerCase().equals("http"))
+		if (theURL.getScheme() == null)
+			return false;
+
+		if (!theURL.getScheme().toLowerCase().equals("http") && !theURL.getScheme().toLowerCase().equals("https"))
 			return false;
 		
 		// check host

--- a/src/com/fsoinstaller/wizard/InstallItem.java
+++ b/src/com/fsoinstaller/wizard/InstallItem.java
@@ -1146,7 +1146,7 @@ public class InstallItem extends JPanel
 		modLogger.info("Patching " + triple.getPrePatch().getFilename());
 		
 		// see if the file exists
-		File prePatchFile = IOUtils.getFileIgnoreCase(modFolder, triple.getPrePatch().getFilename());
+		final File prePatchFile = IOUtils.getFileIgnoreCase(modFolder, triple.getPrePatch().getFilename());
 		if (prePatchFile == null)
 		{
 			modLogger.info("File does not exist; cannot patch it");

--- a/src/io/sigpipe/jbsdiff/Diff.java
+++ b/src/io/sigpipe/jbsdiff/Diff.java
@@ -259,7 +259,7 @@ public class Diff {
 		progressListeners.remove(listener);
 	}
 	
-	private void fireProgress(int current, int total)
+	private void fireProgress(final int current, final int total)
 	{
 		EventQueue.invokeLater(new Runnable()
 		{

--- a/src/io/sigpipe/jbsdiff/Patch.java
+++ b/src/io/sigpipe/jbsdiff/Patch.java
@@ -273,7 +273,7 @@ public class Patch {
 		progressListeners.remove(listener);
 	}
 	
-	private void fireProgress(int current, int total)
+	private void fireProgress(final int current, final int total)
 	{
 		EventQueue.invokeLater(new Runnable()
 		{


### PR DESCRIPTION
There were multiple issues when trying to download build archives from GitHub:
  1. The URL validator only checked if the HTTP protocol was used but GitHub uses HTTPS.
  2. GitHub does not allow HEAD requests for their resources. I added a fallback which uses GET if the HEAD request fails.