### PR TITLE
set "Accept: */*" to workaround java URLConnection bug

### DIFF
--- a/src/com/fsoinstaller/internet/Connector.java
+++ b/src/com/fsoinstaller/internet/Connector.java
@@ -235,7 +235,9 @@ public class Connector
 		
 		// send a fake user agent to prevent 403 Forbidden errors on certain servers
 		conn.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:34.0) Gecko/20100101 Firefox/28.0");
-		conn.setRequestProperty("Accept", "*/*"); // workaround https://bugs.openjdk.org/browse/JDK-8163921
+
+		// work around https://bugs.openjdk.org/browse/JDK-8163921
+		conn.setRequestProperty("Accept", "*/*");
 		
 		return conn;
 	}

--- a/src/com/fsoinstaller/internet/Connector.java
+++ b/src/com/fsoinstaller/internet/Connector.java
@@ -235,6 +235,7 @@ public class Connector
 		
 		// send a fake user agent to prevent 403 Forbidden errors on certain servers
 		conn.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:34.0) Gecko/20100101 Firefox/28.0");
+		conn.setRequestProperty("Accept", "*/*"); // workaround https://bugs.openjdk.org/browse/JDK-8163921
 		
 		return conn;
 	}


### PR DESCRIPTION
explicitly set Accept header to `*/*` to workaround java SDK bug https://bugs.openjdk.org/browse/JDK-8163921 that causes Apache to return a 500 server error attempting to download `mod.ini`